### PR TITLE
Support an option delegateBean in configuration

### DIFF
--- a/ApnsGrailsPlugin.groovy
+++ b/ApnsGrailsPlugin.groovy
@@ -41,6 +41,10 @@ push notifications to an iPhone client of your Grails application.
             certificateResourcePath = application.config.apns.certificateResourcePath ?: null
             password = application.config.apns.password
             environment = configuredEnvironment
+            if ( application.config.apns.delegateBean ) {
+                log.debug "Using delegate ${application.config.apns.delegateBean}"
+                delegateBean = ref( application.config.apns.delegateBean )
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ If you don't have access to your server's file system, you can also replace path
 
 This new configuration system is way better for Heroku deployment.
 
+You can configure a bean to be notified by sent event via the option "delegateBean". This bean must implement the interface com.notnoop.apns.ApnsDelegate.
+
+       apns {
+            pathToCertificate = "/usr/local/myapp/APNs_production_certificates.p12"
+            password = "password"
+            environment = "production"
+            delegateBean = "apnsDelegateService"
+       }
+
 Usage
 =====
 

--- a/src/groovy/org/epseelon/grails/apns/ApnsFactoryBean.groovy
+++ b/src/groovy/org/epseelon/grails/apns/ApnsFactoryBean.groovy
@@ -17,6 +17,7 @@ class ApnsFactoryBean implements FactoryBean {
     boolean queued = false
     Environment environment = Environment.SANDBOX
     boolean nonBlocking = false
+    def delegateBean
 
     Object getObject() {
         def apnsService = APNS.newService()
@@ -48,6 +49,10 @@ class ApnsFactoryBean implements FactoryBean {
 		 */
 		  
         apnsService = apnsService.asQueued()
+
+        if( delegateBean ) {
+            apnsService = apnsService.withDelegate( delegateBean )
+        }
 
         return apnsService.build()
     }


### PR DESCRIPTION
With this update, you can now configure the default apnsService to notify a bean of you application with the sent events.
